### PR TITLE
feat: Add toggle buttons to hide controls and text area

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
         <input type="range" id="speed" min="1" max="10" value="5">
         <label for="fontSize">Font Size:</label>
         <input type="range" id="fontSize" min="12" max="72" value="24">
+        <button id="toggleControlsBtn">Toggle Controls</button>
+        <button id="toggleTextAreaBtn">Toggle Text Area</button>
     </div>
     <textarea id="textInput" placeholder="Paste your script here..."></textarea>
     <div id="teleprompter">

--- a/script.js
+++ b/script.js
@@ -6,6 +6,9 @@ const fontSizeInput = document.getElementById('fontSize');
 const textInput = document.getElementById('textInput');
 const teleprompter = document.getElementById('teleprompter');
 const textDisplay = document.getElementById('textDisplay');
+const toggleControlsBtn = document.getElementById('toggleControlsBtn');
+const toggleTextAreaBtn = document.getElementById('toggleTextAreaBtn');
+const controls = document.querySelector('.controls');
 
 let isScrolling = false;
 let scrollInterval;
@@ -71,4 +74,12 @@ scrollDownBtn.addEventListener('mouseup', () => {
 
 scrollDownBtn.addEventListener('mouseleave', () => {
     clearInterval(scrollDownInterval);
+});
+
+toggleControlsBtn.addEventListener('click', () => {
+    controls.classList.toggle('hidden');
+});
+
+toggleTextAreaBtn.addEventListener('click', () => {
+    textInput.classList.toggle('hidden');
 });

--- a/style.css
+++ b/style.css
@@ -49,3 +49,15 @@ body {
     margin: 0 auto;
     white-space: pre-wrap;
 }
+
+.hidden {
+    display: none;
+}
+
+#toggleControlsBtn, #toggleTextAreaBtn {
+    background-color: #555;
+    color: white;
+    border: none;
+    padding: 5px 10px;
+    cursor: pointer;
+}


### PR DESCRIPTION
This commit introduces two new buttons, "Toggle Controls" and "Toggle Text Area", to the teleprompter application. These buttons allow the user to hide the control panel and the text input area, providing a clean view of the scrolling text for recording purposes.